### PR TITLE
Remove unnecessary macro

### DIFF
--- a/data/gm/functions/square.mcfunction
+++ b/data/gm/functions/square.mcfunction
@@ -7,4 +7,4 @@ data modify storage gm:io out set from entity 91bb5-0-0-0-ffff transformation.tr
 return run data get storage gm:io out
 
 return fail
-$tp invalid-input $(x) 0
+$tp invalid-input $(x) 0 0

--- a/data/gm/functions/square.mcfunction
+++ b/data/gm/functions/square.mcfunction
@@ -7,4 +7,4 @@ data modify storage gm:io out set from entity 91bb5-0-0-0-ffff transformation.tr
 return run data get storage gm:io out
 
 return fail
-$tp invalid-input $(x) $(y) 0
+$tp invalid-input $(x) 0


### PR DESCRIPTION
# The Problem
Running the following function:
```
gm:square {x: <value>}
```
results in the following error:
`Failed to instantiate function gm:square: Missing argument y to function gm:square`
# Solution description
Removing the macro `$(y)` and replacing it with the hard-coded value `0` fixes the issue