### PR TITLE
Small fixes

### DIFF
--- a/data/gm/functions/zzz/sqrt_handling/positive_subtract.mcfunction
+++ b/data/gm/functions/zzz/sqrt_handling/positive_subtract.mcfunction
@@ -1,2 +1,2 @@
-$execute positioned ~ $(var1) ~ positioned ~ ~-0.000000001 ~ run tp 91bb5-0-0-0-ffff 29999999 ~-$(var2) 91665
+$execute positioned ~ $(var1) ~ positioned ~ ~-0.000001 ~ run tp 91bb5-0-0-0-ffff 29999999 ~-$(var2) 91665
 data modify storage gm:temp v1m2p set string entity 91bb5-0-0-0-ffff Pos[1] 0 1

--- a/pack.mcmeta
+++ b/pack.mcmeta
@@ -1,6 +1,10 @@
 {
-	"pack": {
-		"pack_format": 16,
-		"description": "§7Floating Point Arithmetic §b- §7by gibbsly \n§7[§dgithub.com/gibbsly/gm§7]"
-	}
+  "pack": {
+    "pack_format": 18,
+    "supported_formats": {
+      "min_inclusive": 18,
+      "max_inclusive": 26
+    },
+    "description": "§7Floating Point Arithmetic §b- §7by gibbsly \n§7[§dgithub.com/gibbsly/gm§7]"
+  }
 }


### PR DESCRIPTION
# The Problems
- Square Root function sometimes runs infinitely, because threshold requires it to be more accurate than it can be.
- pack.mcmeta is outdated
# Solution description
- Tried to prevent sqrt runaways by decreasing accuracy threshold value. Still very accurate, but runs away a lot less. (NOTE: May need to add a max run count in the future)
- Updated pack.mcmeta to have a minimum pack_format of 18 (Required for macro usage). Also added supported format min-max range for more versatility.