### PR TITLE
Add inverse trigonometric functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,14 @@ these functions only requires `{x:(number)}` as an argument
 
 > does `1 / x`
 
+### `gm:square`
+
+> does `x^2`
+
+### `gm:sqrt`
+
+> does `√x`
+
 ### `gm:sin`
 
 > does `sin(x)`
@@ -64,10 +72,10 @@ these functions only requires `{x:(number)}` as an argument
 
 also outputs sin to `storage gm:temp var1` and cos to `storage gm:temp var2`
 
-### `gm:square`
+### `gm:arcsin`
 
-> does `x^2`
+> does `sin⁻¹(x)`
 
-### `gm:sqrt`
+### `gm:arccos`
 
-> does `√x`
+> does `cos⁻¹(x)`

--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ outputs the resulting numbers in an array in the default output location and ret
 
 for this operation 2 position arrays must be given instead of single values. If an array is empty or values are unspecified, the values will default to 0
 
+### `gm:arctan2`
+
+> does `atan2(y, x)`
+
+this operation is similar to doing `tan⁻¹(y/x)`, except that `-180 ≤ atan2(y, x) ≤ 180`. This gives a full 360° result, compared the 180° result of just doing `tan⁻¹(y/x)`
+
 ## single input functions
 
 these functions only requires `{x:(number)}` as an argument
@@ -76,6 +82,16 @@ also outputs sin to `storage gm:temp var1` and cos to `storage gm:temp var2`
 
 > does `sin⁻¹(x)`
 
+`-90 ≤ sin⁻¹(x) ≤ 90` where `-1 ≤ x ≤ 1`
+
 ### `gm:arccos`
 
 > does `cos⁻¹(x)`
+
+`0 ≤ cos⁻¹(x) ≤ 180` where `-1 ≤ x ≤ 1`
+
+### `gm:arctan`
+
+> does `tan⁻¹(x)`
+
+`-90 ≤ tan⁻¹(x) ≤ 90`

--- a/data/gm/functions/arccos.mcfunction
+++ b/data/gm/functions/arccos.mcfunction
@@ -1,0 +1,11 @@
+data modify storage gm:io out set value "fail"
+$data modify storage gm:temp var1 set value [0f,0f,0f,$(x)f,0f,1f,0f,0f,0f,0f,1f,0f,0f,0f,0f,1f]
+$data modify entity 91bb5-0-0-0-ffff transformation set value [0f,0f,0f,1f,0f,1f,0f,0f,0f,0f,1f,0f,0f,0f,0f,$(x)f]
+execute unless function gm:zzz/inverse_trig/get_opposite run return fail
+$data modify storage gm:temp var2 set value $(x)f
+function gm:zzz/inverse_trig/negate_val with storage gm:temp
+data modify storage gm:temp var1 set from storage gm:io out
+execute as 91bb5-0-0-0-ffff run return run function gm:zzz/inverse_trig/handling with storage gm:temp
+
+return fail
+$tp invalid-input $(x) 0 0

--- a/data/gm/functions/arcsin.mcfunction
+++ b/data/gm/functions/arcsin.mcfunction
@@ -1,0 +1,11 @@
+data modify storage gm:io out set value "fail"
+$data modify storage gm:temp var1 set value [0f,0f,0f,$(x)f,0f,1f,0f,0f,0f,0f,1f,0f,0f,0f,0f,1f]
+$data modify entity 91bb5-0-0-0-ffff transformation set value [0f,0f,0f,1f,0f,1f,0f,0f,0f,0f,1f,0f,0f,0f,0f,$(x)f]
+execute unless function gm:zzz/inverse_trig/get_opposite run return fail
+data modify storage gm:temp var2 set from storage gm:io out
+function gm:zzz/inverse_trig/negate_val with storage gm:temp
+$data modify storage gm:temp var1 set value $(x)f
+execute as 91bb5-0-0-0-ffff run return run function gm:zzz/inverse_trig/handling with storage gm:temp
+
+return fail
+$tp invalid-input $(x) 0 0

--- a/data/gm/functions/arctan.mcfunction
+++ b/data/gm/functions/arctan.mcfunction
@@ -1,0 +1,25 @@
+data modify storage gm:io out set value "fail"
+$data merge storage gm:temp {var1:[0f,0f,0f,$(x)f,0f,1f,0f,0f,0f,0f,1f,0f,0f,0f,0f,1f],var7:[0d,0d,0d,1d,0d,1d,0d,0d,0d,0d,1d,0d,0d,0d,0d,0d]}
+data modify storage gm:temp pol set string storage gm:temp var1[3] 0 1
+$data modify entity 91bb5-0-0-0-ffff transformation set value [0f,0f,0f,1f,0f,1f,0f,0f,0f,0f,1f,0f,0f,0f,0f,$(x)f]
+data modify storage gm:temp var1[-1] set from entity 91bb5-0-0-0-ffff transformation.translation[0]
+data modify entity 91bb5-0-0-0-ffff transformation set from storage gm:temp var1
+data modify storage gm:temp var5 set from entity 91bb5-0-0-0-ffff transformation.translation[0]
+function gm:zzz/arctan/add_one with storage gm:temp
+data modify storage gm:temp var7[-1] set from storage gm:temp var6
+data modify entity 91bb5-0-0-0-ffff transformation set from storage gm:temp var7
+data modify storage gm:temp x set from entity 91bb5-0-0-0-ffff transformation.translation[0]
+function gm:sqrt with storage gm:temp
+data modify storage gm:temp var6 set from storage gm:io out
+data modify storage gm:temp var7[3] set from storage gm:temp var5
+data modify entity 91bb5-0-0-0-ffff transformation set from storage gm:temp var7
+data modify storage gm:temp x set from entity 91bb5-0-0-0-ffff transformation.translation[0]
+function gm:sqrt with storage gm:temp
+data modify storage gm:temp var2 set from storage gm:temp var6
+function gm:zzz/inverse_trig/negate_val with storage gm:temp
+data modify storage gm:temp var1 set from storage gm:io out
+execute if data storage gm:temp {pol:"-"} run function gm:zzz/arctan/negate_val with storage gm:temp
+execute as 91bb5-0-0-0-ffff run return run function gm:zzz/inverse_trig/handling with storage gm:temp
+
+return fail
+$tp invalid-input $(x) 0 0

--- a/data/gm/functions/arctan2.mcfunction
+++ b/data/gm/functions/arctan2.mcfunction
@@ -1,0 +1,10 @@
+data modify storage gm:io out set value "fail"
+$data modify storage gm:temp var2 set value $(x)f
+function gm:zzz/inverse_trig/negate_val with storage gm:temp
+$data modify storage gm:temp var1 set value $(y)f
+execute if data storage gm:temp {var1:0f, var2:0f} run return fail
+tellraw @a [{"nbt":"var1", "storage":"gm:temp"},{"nbt":"var2", "storage":"gm:temp"}]
+execute as 91bb5-0-0-0-ffff run return run function gm:zzz/inverse_trig/handling with storage gm:temp
+
+return fail
+$tp invalid-input $(x) $(y) 0

--- a/data/gm/functions/arctan2.mcfunction
+++ b/data/gm/functions/arctan2.mcfunction
@@ -3,7 +3,6 @@ $data modify storage gm:temp var2 set value $(x)f
 function gm:zzz/inverse_trig/negate_val with storage gm:temp
 $data modify storage gm:temp var1 set value $(y)f
 execute if data storage gm:temp {var1:0f, var2:0f} run return fail
-tellraw @a [{"nbt":"var1", "storage":"gm:temp"},{"nbt":"var2", "storage":"gm:temp"}]
 execute as 91bb5-0-0-0-ffff run return run function gm:zzz/inverse_trig/handling with storage gm:temp
 
 return fail

--- a/data/gm/functions/zzz/arctan/add_one.mcfunction
+++ b/data/gm/functions/zzz/arctan/add_one.mcfunction
@@ -1,0 +1,3 @@
+$execute positioned ~ 1 ~ run tp 91bb5-0-0-0-ffff ~ ~$(var5) ~
+data modify storage gm:temp var6 set from entity 91bb5-0-0-0-ffff Pos[1]
+$data modify storage gm:temp var5 set value $(var5)d

--- a/data/gm/functions/zzz/arctan/negate_val.mcfunction
+++ b/data/gm/functions/zzz/arctan/negate_val.mcfunction
@@ -1,0 +1,3 @@
+$data modify storage gm:temp var1 set value [0f,0f,0f,$(var1)f,0f,1f,0f,0f,0f,0f,1f,0f,0f,0f,0f,-1f]
+data modify entity 91bb5-0-0-0-ffff transformation set from storage gm:temp var1
+data modify storage gm:temp var1 set from entity 91bb5-0-0-0-ffff transformation.translation[0]

--- a/data/gm/functions/zzz/inverse_trig/get_opposite.mcfunction
+++ b/data/gm/functions/zzz/inverse_trig/get_opposite.mcfunction
@@ -1,0 +1,7 @@
+data modify storage gm:temp var1[-1] set from entity 91bb5-0-0-0-ffff transformation.translation[0]
+data modify entity 91bb5-0-0-0-ffff transformation set from storage gm:temp var1
+data modify storage gm:temp var1 set from entity 91bb5-0-0-0-ffff transformation.translation[0]
+function gm:zzz/inverse_trig/range_check with storage gm:temp
+execute if data storage gm:temp {v1sqp:"-"} run return fail
+function gm:sqrt with storage gm:temp
+return 1

--- a/data/gm/functions/zzz/inverse_trig/handling.mcfunction
+++ b/data/gm/functions/zzz/inverse_trig/handling.mcfunction
@@ -1,0 +1,6 @@
+$data modify entity @s Pos set value [$(var1)d,0.0d,$(var2)d]
+execute at @s run tp @s ~ ~ ~ facing 0.0 0.0 0.0
+data modify storage gm:io out set from entity @s Rotation[0]
+tp @s 29999999 0 91665
+execute if data storage gm:io {out:-180f} run data merge storage gm:io {out:180.0f}
+return run data get storage gm:io out

--- a/data/gm/functions/zzz/inverse_trig/negate_val.mcfunction
+++ b/data/gm/functions/zzz/inverse_trig/negate_val.mcfunction
@@ -1,0 +1,3 @@
+$data modify storage gm:temp var1 set value [0f,0f,0f,$(var2)f,0f,1f,0f,0f,0f,0f,1f,0f,0f,0f,0f,-1f]
+data modify entity 91bb5-0-0-0-ffff transformation set from storage gm:temp var1
+data modify storage gm:temp var2 set from entity 91bb5-0-0-0-ffff transformation.translation[0]

--- a/data/gm/functions/zzz/inverse_trig/range_check.mcfunction
+++ b/data/gm/functions/zzz/inverse_trig/range_check.mcfunction
@@ -1,0 +1,3 @@
+$execute positioned ~ 1 ~ run tp 91bb5-0-0-0-ffff ~ ~-$(var1) ~
+data modify storage gm:temp x set from entity 91bb5-0-0-0-ffff Pos[1]
+data modify storage gm:temp v1sqp set string storage gm:temp x 0 1


### PR DESCRIPTION
# The Suggestion
Add the following functions:
- `sin⁻¹(x)`
- `cos⁻¹(x)`
- `tan⁻¹(x)`
- `atan2(y, x)`
# Implementation description
- All implementations except for `gm:arctan2` use the sqrt function from #4 
- `gm:arcsin`, `gm:arccos` and `gm:arctan` fail when `$(x)` is not present
  - `gm:arcsin` and `gm:arccos` both fail when `$(x)` is not with the bounds `-1 ≤ x ≤ 1`
- `gm:arctan2(y, x)` fails when either `$(x)` or `$(y)` are not present
  - Thanks to certain quirks of how minecraft works, `gm:arctan2(y, x)` is actually more efficient than `gm:arctan`
- Ensured same formatting and error checking to the original codebase
- Updated README to add `gm:arcsin`, `gm:arccos`, `gm:arctan` and `gm:arctan2` to list of functions