### PR TITLE
Add IMP

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ these functions only requires `{x:(number)}` as an argument
 
 > does `tan(x)`
 
-also outputs sin to `storage gm:temp var1` and cos to `storage gm:temp var2`
+also outputs sin to `storage gm._temp_:std var1` and cos to `storage gm._temp_:std var2`
 
 ### `gm:arcsin`
 

--- a/data/gm/functions/add.mcfunction
+++ b/data/gm/functions/add.mcfunction
@@ -1,3 +1,23 @@
+#> gm:add
+#
+# ## Gets the sum of two values
+#
+# Equivalent to `x + y`
+#
+# Has a max output range of -20000000 to 19999999, outside of which, this function returns 0
+#
+# ---
+# @context any
+# @api
+# @macro
+#   x: float | double
+#      One of the values to add
+#   y: float | double
+#      One of the values to add
+# @output
+#   storage gm:io
+#      out: double | "fail"
+
 data modify storage gm:io out set value "fail"
 $execute positioned ~ $(x) ~ run tp 91bb5-0-0-0-ffff 29999999 ~$(y) 91665
 data modify storage gm:io out set from entity 91bb5-0-0-0-ffff Pos[1]

--- a/data/gm/functions/arccos.mcfunction
+++ b/data/gm/functions/arccos.mcfunction
@@ -1,11 +1,32 @@
+#> gm:arccos
+#
+# ## Gets the arccosine of a value
+#
+# Equivalent to `cos⁻¹(x)`
+#
+# Outputs in degrees from `0` to `+180`
+#
+# # Fails
+# Will fail if `x < -1` or if `x > 1`
+#
+# ---
+# @context any
+# @api
+# @macro
+#   x: float | double
+#      The value to get the arccosine of
+# @output
+#   storage gm:io
+#      out: float | "fail"
+
 data modify storage gm:io out set value "fail"
-$data modify storage gm:temp var1 set value [0f,0f,0f,$(x)f,0f,1f,0f,0f,0f,0f,1f,0f,0f,0f,0f,1f]
+$data modify storage gm._temp_:std var1 set value [0f,0f,0f,$(x)f,0f,1f,0f,0f,0f,0f,1f,0f,0f,0f,0f,1f]
 $data modify entity 91bb5-0-0-0-ffff transformation set value [0f,0f,0f,1f,0f,1f,0f,0f,0f,0f,1f,0f,0f,0f,0f,$(x)f]
 execute unless function gm:zzz/inverse_trig/get_opposite run return fail
-$data modify storage gm:temp var2 set value $(x)f
-function gm:zzz/inverse_trig/negate_val with storage gm:temp
-data modify storage gm:temp var1 set from storage gm:io out
-execute as 91bb5-0-0-0-ffff run return run function gm:zzz/inverse_trig/handling with storage gm:temp
+$data modify storage gm._temp_:std var2 set value $(x)f
+function gm:zzz/inverse_trig/negate_val with storage gm._temp_:std
+data modify storage gm._temp_:std var1 set from storage gm:io out
+execute as 91bb5-0-0-0-ffff run return run function gm:zzz/inverse_trig/handling with storage gm._temp_:std
 
 return fail
 $tp invalid-input $(x) 0 0

--- a/data/gm/functions/arcsin.mcfunction
+++ b/data/gm/functions/arcsin.mcfunction
@@ -1,11 +1,32 @@
+#> gm:arcsin
+#
+# ## Gets the arcsine of a value
+#
+# Equivalent to `sin⁻¹(x)`
+#
+# Outputs in degrees from `-90` to `+90`
+#
+# # Fails
+# Will fail if `x < -1` or if `x > 1`
+#
+# ---
+# @context any
+# @api
+# @macro
+#   x: float | double
+#      The value to get the arcsine of
+# @output
+#   storage gm:io
+#      out: float | "fail"
+
 data modify storage gm:io out set value "fail"
-$data modify storage gm:temp var1 set value [0f,0f,0f,$(x)f,0f,1f,0f,0f,0f,0f,1f,0f,0f,0f,0f,1f]
+$data modify storage gm._temp_:std var1 set value [0f,0f,0f,$(x)f,0f,1f,0f,0f,0f,0f,1f,0f,0f,0f,0f,1f]
 $data modify entity 91bb5-0-0-0-ffff transformation set value [0f,0f,0f,1f,0f,1f,0f,0f,0f,0f,1f,0f,0f,0f,0f,$(x)f]
 execute unless function gm:zzz/inverse_trig/get_opposite run return fail
-data modify storage gm:temp var2 set from storage gm:io out
-function gm:zzz/inverse_trig/negate_val with storage gm:temp
-$data modify storage gm:temp var1 set value $(x)f
-execute as 91bb5-0-0-0-ffff run return run function gm:zzz/inverse_trig/handling with storage gm:temp
+data modify storage gm._temp_:std var2 set from storage gm:io out
+function gm:zzz/inverse_trig/negate_val with storage gm._temp_:std
+$data modify storage gm._temp_:std var1 set value $(x)f
+execute as 91bb5-0-0-0-ffff run return run function gm:zzz/inverse_trig/handling with storage gm._temp_:std
 
 return fail
 $tp invalid-input $(x) 0 0

--- a/data/gm/functions/arctan.mcfunction
+++ b/data/gm/functions/arctan.mcfunction
@@ -1,25 +1,46 @@
+#> gm:arctan
+#
+# ## Gets the arctangent of a value
+#
+# Equivalent to `tan⁻¹(x)`
+#
+# Outputs in degrees from `-90` to `+90`
+#
+# # Fails
+# Will fail if `x < -1719` or if `x > 1719`
+#
+# ---
+# @context any
+# @api
+# @macro
+#   x: float | double
+#      The value to get the arctangent of
+# @output
+#   storage gm:io
+#      out: float | "fail"
+
 data modify storage gm:io out set value "fail"
-$data merge storage gm:temp {var1:[0f,0f,0f,$(x)f,0f,1f,0f,0f,0f,0f,1f,0f,0f,0f,0f,1f],var7:[0d,0d,0d,1d,0d,1d,0d,0d,0d,0d,1d,0d,0d,0d,0d,0d]}
-data modify storage gm:temp pol set string storage gm:temp var1[3] 0 1
+$data merge storage gm._temp_:std {var1:[0f,0f,0f,$(x)f,0f,1f,0f,0f,0f,0f,1f,0f,0f,0f,0f,1f],var7:[0d,0d,0d,1d,0d,1d,0d,0d,0d,0d,1d,0d,0d,0d,0d,0d]}
+data modify storage gm._temp_:std pol set string storage gm._temp_:std var1[3] 0 1
 $data modify entity 91bb5-0-0-0-ffff transformation set value [0f,0f,0f,1f,0f,1f,0f,0f,0f,0f,1f,0f,0f,0f,0f,$(x)f]
-data modify storage gm:temp var1[-1] set from entity 91bb5-0-0-0-ffff transformation.translation[0]
-data modify entity 91bb5-0-0-0-ffff transformation set from storage gm:temp var1
-data modify storage gm:temp var5 set from entity 91bb5-0-0-0-ffff transformation.translation[0]
-function gm:zzz/arctan/add_one with storage gm:temp
-data modify storage gm:temp var7[-1] set from storage gm:temp var6
-data modify entity 91bb5-0-0-0-ffff transformation set from storage gm:temp var7
-data modify storage gm:temp x set from entity 91bb5-0-0-0-ffff transformation.translation[0]
-function gm:sqrt with storage gm:temp
-data modify storage gm:temp var6 set from storage gm:io out
-data modify storage gm:temp var7[3] set from storage gm:temp var5
-data modify entity 91bb5-0-0-0-ffff transformation set from storage gm:temp var7
-data modify storage gm:temp x set from entity 91bb5-0-0-0-ffff transformation.translation[0]
-function gm:sqrt with storage gm:temp
-data modify storage gm:temp var2 set from storage gm:temp var6
-function gm:zzz/inverse_trig/negate_val with storage gm:temp
-data modify storage gm:temp var1 set from storage gm:io out
-execute if data storage gm:temp {pol:"-"} run function gm:zzz/arctan/negate_val with storage gm:temp
-execute as 91bb5-0-0-0-ffff run return run function gm:zzz/inverse_trig/handling with storage gm:temp
+data modify storage gm._temp_:std var1[-1] set from entity 91bb5-0-0-0-ffff transformation.translation[0]
+data modify entity 91bb5-0-0-0-ffff transformation set from storage gm._temp_:std var1
+data modify storage gm._temp_:std var5 set from entity 91bb5-0-0-0-ffff transformation.translation[0]
+function gm:zzz/arctan/add_one with storage gm._temp_:std
+data modify storage gm._temp_:std var7[-1] set from storage gm._temp_:std var6
+data modify entity 91bb5-0-0-0-ffff transformation set from storage gm._temp_:std var7
+data modify storage gm._temp_:std x set from entity 91bb5-0-0-0-ffff transformation.translation[0]
+function gm:sqrt with storage gm._temp_:std
+data modify storage gm._temp_:std var6 set from storage gm:io out
+data modify storage gm._temp_:std var7[3] set from storage gm._temp_:std var5
+data modify entity 91bb5-0-0-0-ffff transformation set from storage gm._temp_:std var7
+data modify storage gm._temp_:std x set from entity 91bb5-0-0-0-ffff transformation.translation[0]
+function gm:sqrt with storage gm._temp_:std
+data modify storage gm._temp_:std var2 set from storage gm._temp_:std var6
+function gm:zzz/inverse_trig/negate_val with storage gm._temp_:std
+data modify storage gm._temp_:std var1 set from storage gm:io out
+execute if data storage gm._temp_:std {pol:"-"} run function gm:zzz/arctan/negate_val with storage gm._temp_:std
+execute as 91bb5-0-0-0-ffff run return run function gm:zzz/inverse_trig/handling with storage gm._temp_:std
 
 return fail
 $tp invalid-input $(x) 0 0

--- a/data/gm/functions/arctan2.mcfunction
+++ b/data/gm/functions/arctan2.mcfunction
@@ -1,9 +1,34 @@
+#> gm:arctan2
+#
+# ## Gets the arctangent of a point
+#
+# Equivalent to `atan(y, x)`
+# 
+# Measures the counterclockwise angle from the positive x axis to the point `(x, y)`.
+#
+# Outputs in degrees from `-180` to `+180`
+#
+# # Fails
+# Will fail if `x=0` and `y=0` at the same time
+#
+# ---
+# @context any
+# @api
+# @macro
+#   x: float | double
+#      The x position of the point
+#   y: float | double
+#      The y position of the point
+# @output
+#   storage gm:io
+#      out: float | "fail"
+
 data modify storage gm:io out set value "fail"
-$data modify storage gm:temp var2 set value $(x)f
-function gm:zzz/inverse_trig/negate_val with storage gm:temp
-$data modify storage gm:temp var1 set value $(y)f
-execute if data storage gm:temp {var1:0f, var2:0f} run return fail
-execute as 91bb5-0-0-0-ffff run return run function gm:zzz/inverse_trig/handling with storage gm:temp
+$data modify storage gm._temp_:std var2 set value $(x)f
+function gm:zzz/inverse_trig/negate_val with storage gm._temp_:std
+$data modify storage gm._temp_:std var1 set value $(y)f
+execute if data storage gm._temp_:std {var1:0f, var2:0f} run return fail
+execute as 91bb5-0-0-0-ffff run return run function gm:zzz/inverse_trig/handling with storage gm._temp_:std
 
 return fail
 $tp invalid-input $(x) $(y) 0

--- a/data/gm/functions/cos.mcfunction
+++ b/data/gm/functions/cos.mcfunction
@@ -1,3 +1,21 @@
+#> gm:cos
+#
+# ## Gets the cosine of a value
+#
+# Equivalent to `cos(x)`
+#
+# Outputs from `-1` to `+1`
+#
+# ---
+# @context any
+# @api
+# @macro
+#   x: float | double
+#      The value to get the cosine of in degrees
+# @output
+#   storage gm:io
+#      out: double | "fail"
+
 data modify storage gm:io out set value "fail"
 $execute rotated $(x) 0 positioned 0.0 0.0 0.0 positioned ^ ^ ^1 as 91bb5-0-0-0-ffff run return run function gm:zzz/cos_handling
 

--- a/data/gm/functions/distance.mcfunction
+++ b/data/gm/functions/distance.mcfunction
@@ -1,48 +1,70 @@
+#> gm:distance
+#
+# ## Gets the distance between two values
+#
+# Gets the distance between the arrays `x` and `y`
+#
+# Position arrays can be up to 3 elements long
+#
+# If a element is missing from an array, it's assumed to be 0 instead
+#
+# ---
+# @context any
+# @api
+# @macro
+#   x: (float | double)[]
+#      One of the position arrays
+#   y: (float | double)[]
+#      One of the position arrays
+# @output
+#   storage gm:io
+#      out: float[] | "fail"
+
 data modify storage gm:io out set value "fail"
-data modify storage gm:temp dist set value {}
+data modify storage gm._temp_:std dist set value {}
 
 #setup
-data modify storage gm:temp var1 set value {}
-$data modify storage gm:temp ar1 set value $(x)
-$data modify storage gm:temp ar2 set value $(y)
+data modify storage gm._temp_:std var1 set value {}
+$data modify storage gm._temp_:std ar1 set value $(x)
+$data modify storage gm._temp_:std ar2 set value $(y)
 
 #x
-data modify storage gm:temp var2 set value {x:0,y:0}
-data modify storage gm:temp var2.x set from storage gm:temp ar1[0]
-data modify storage gm:temp var2.y set from storage gm:temp ar2[0]
-function gm:subtract with storage gm:temp var2
-data modify storage gm:temp tv2p set string storage gm:io out 0 1
-execute if data storage gm:temp {tv2p:"-"} run data modify storage gm:temp var2 set value {x:0,y:0}
-execute if data storage gm:temp {tv2p:"-"} run data modify storage gm:temp var2.y set from storage gm:temp ar1[0]
-execute if data storage gm:temp {tv2p:"-"} run data modify storage gm:temp var2.x set from storage gm:temp ar2[0]
-execute if data storage gm:temp {tv2p:"-"} run function gm:subtract with storage gm:temp var2
-data modify storage gm:temp dist.x set from storage gm:io out
+data modify storage gm._temp_:std var2 set value {x:0,y:0}
+data modify storage gm._temp_:std var2.x set from storage gm._temp_:std ar1[0]
+data modify storage gm._temp_:std var2.y set from storage gm._temp_:std ar2[0]
+function gm:subtract with storage gm._temp_:std var2
+data modify storage gm._temp_:std tv2p set string storage gm:io out 0 1
+execute if data storage gm._temp_:std {tv2p:"-"} run data modify storage gm._temp_:std var2 set value {x:0,y:0}
+execute if data storage gm._temp_:std {tv2p:"-"} run data modify storage gm._temp_:std var2.y set from storage gm._temp_:std ar1[0]
+execute if data storage gm._temp_:std {tv2p:"-"} run data modify storage gm._temp_:std var2.x set from storage gm._temp_:std ar2[0]
+execute if data storage gm._temp_:std {tv2p:"-"} run function gm:subtract with storage gm._temp_:std var2
+data modify storage gm._temp_:std dist.x set from storage gm:io out
 
 #y
-data modify storage gm:temp var2 set value {x:0,y:0}
-data modify storage gm:temp var2.x set from storage gm:temp ar1[1]
-data modify storage gm:temp var2.y set from storage gm:temp ar2[1]
-function gm:subtract with storage gm:temp var2
-data modify storage gm:temp tv2p set string storage gm:io out 0 1
-execute if data storage gm:temp {tv2p:"-"} run data modify storage gm:temp var2 set value {x:0,y:0}
-execute if data storage gm:temp {tv2p:"-"} run data modify storage gm:temp var2.y set from storage gm:temp ar1[1]
-execute if data storage gm:temp {tv2p:"-"} run data modify storage gm:temp var2.x set from storage gm:temp ar2[1]
-execute if data storage gm:temp {tv2p:"-"} run function gm:subtract with storage gm:temp var2
-data modify storage gm:temp dist.y set from storage gm:io out
+data modify storage gm._temp_:std var2 set value {x:0,y:0}
+data modify storage gm._temp_:std var2.x set from storage gm._temp_:std ar1[1]
+data modify storage gm._temp_:std var2.y set from storage gm._temp_:std ar2[1]
+function gm:subtract with storage gm._temp_:std var2
+data modify storage gm._temp_:std tv2p set string storage gm:io out 0 1
+execute if data storage gm._temp_:std {tv2p:"-"} run data modify storage gm._temp_:std var2 set value {x:0,y:0}
+execute if data storage gm._temp_:std {tv2p:"-"} run data modify storage gm._temp_:std var2.y set from storage gm._temp_:std ar1[1]
+execute if data storage gm._temp_:std {tv2p:"-"} run data modify storage gm._temp_:std var2.x set from storage gm._temp_:std ar2[1]
+execute if data storage gm._temp_:std {tv2p:"-"} run function gm:subtract with storage gm._temp_:std var2
+data modify storage gm._temp_:std dist.y set from storage gm:io out
 
 #z
-data modify storage gm:temp var2 set value {x:0,y:0}
-data modify storage gm:temp var2.x set from storage gm:temp ar1[2]
-data modify storage gm:temp var2.y set from storage gm:temp ar2[2]
-function gm:subtract with storage gm:temp var2
-data modify storage gm:temp tv2p set string storage gm:io out 0 1
-execute if data storage gm:temp {tv2p:"-"} run data modify storage gm:temp var2 set value {x:0,y:0}
-execute if data storage gm:temp {tv2p:"-"} run data modify storage gm:temp var2.y set from storage gm:temp ar1[2]
-execute if data storage gm:temp {tv2p:"-"} run data modify storage gm:temp var2.x set from storage gm:temp ar2[2]
-execute if data storage gm:temp {tv2p:"-"} run function gm:subtract with storage gm:temp var2
-data modify storage gm:temp dist.z set from storage gm:io out
+data modify storage gm._temp_:std var2 set value {x:0,y:0}
+data modify storage gm._temp_:std var2.x set from storage gm._temp_:std ar1[2]
+data modify storage gm._temp_:std var2.y set from storage gm._temp_:std ar2[2]
+function gm:subtract with storage gm._temp_:std var2
+data modify storage gm._temp_:std tv2p set string storage gm:io out 0 1
+execute if data storage gm._temp_:std {tv2p:"-"} run data modify storage gm._temp_:std var2 set value {x:0,y:0}
+execute if data storage gm._temp_:std {tv2p:"-"} run data modify storage gm._temp_:std var2.y set from storage gm._temp_:std ar1[2]
+execute if data storage gm._temp_:std {tv2p:"-"} run data modify storage gm._temp_:std var2.x set from storage gm._temp_:std ar2[2]
+execute if data storage gm._temp_:std {tv2p:"-"} run function gm:subtract with storage gm._temp_:std var2
+data modify storage gm._temp_:std dist.z set from storage gm:io out
 
-execute unless data storage gm:temp dist{x:"fail"} unless data storage gm:temp dist{y:"fail"} unless data storage gm:temp dist{z:"fail"} run return run function gm:zzz/distance_handling with storage gm:temp dist
+execute unless data storage gm._temp_:std dist{x:"fail"} unless data storage gm._temp_:std dist{y:"fail"} unless data storage gm._temp_:std dist{z:"fail"} run return run function gm:zzz/distance_handling with storage gm._temp_:std dist
 
 return fail
 $data modify storage invalid input set value [[],$(x),$(y)]

--- a/data/gm/functions/divide.mcfunction
+++ b/data/gm/functions/divide.mcfunction
@@ -1,8 +1,30 @@
+#> gm:divide
+#
+# ## Gets the quotient of two values
+#
+# Equivalent to `x / y`
+#
+# `x` can be either a single number, or an array of numbers, up to 3 elements long
+# 
+# If `x` is an array, the result is equivalent to `[x[0]/y,x[1]/y,x[2]/y]`
+#
+# ---
+# @context any
+# @api
+# @macro
+#   x: (float | double)[] | float | double
+#      The numerator, or array of numerators
+#   y: float | double
+#      The denominator
+# @output
+#   storage gm:io
+#      out: float[] | float | "fail"
+
 data modify storage gm:io out set value "fail"
-data merge storage gm:check {type:0,string:["a"],number:[1d],array:[[]],object:[{}]}
-$execute store result storage gm:check type int 1 run function gm:zzz/get_data_type {value:$(x)}
-$execute if data storage gm:check {type:1} run return run function gm:zzz/divide_handling {var1:$(x),var2:$(y)}
-$execute if data storage gm:check {type:2} run return run function gm:zzz/divide_array {array:$(x),divisor:$(y)}
+data merge storage gm._temp_:check {type:0,string:["a"],number:[1d],array:[[]],object:[{}]}
+$execute store result storage gm._temp_:check type int 1 run function gm:zzz/get_data_type {value:$(x)}
+$execute if data storage gm._temp_:check {type:1} run return run function gm:zzz/divide_handling {var1:$(x),var2:$(y)}
+$execute if data storage gm._temp_:check {type:2} run return run function gm:zzz/divide_array {array:$(x),divisor:$(y)}
 
 return fail
 $tp invalid-input 0 $(y) 0

--- a/data/gm/functions/multiply.mcfunction
+++ b/data/gm/functions/multiply.mcfunction
@@ -1,8 +1,26 @@
+#> gm:multiply
+#
+# ## Gets the product of two values
+#
+# Equivalent to `x * y`
+#
+# ---
+# @context any
+# @api
+# @macro
+#   x: float | double
+#      One of the values to multiply
+#   y: float | double
+#      One of the values to multiply
+# @output
+#   storage gm:io
+#      out: float | "fail"
+
 data modify storage gm:io out set value "fail"
-$data modify storage gm:temp var1 set value [0f,0f,0f,$(x)f,0f,1f,0f,0f,0f,0f,1f,0f,0f,0f,0f,1f]
+$data modify storage gm._temp_:std var1 set value [0f,0f,0f,$(x)f,0f,1f,0f,0f,0f,0f,1f,0f,0f,0f,0f,1f]
 $data modify entity 91bb5-0-0-0-ffff transformation set value [0f,0f,0f,1f,0f,1f,0f,0f,0f,0f,1f,0f,0f,0f,0f,$(y)f]
-data modify storage gm:temp var1[-1] set from entity 91bb5-0-0-0-ffff transformation.translation[0]
-data modify entity 91bb5-0-0-0-ffff transformation set from storage gm:temp var1
+data modify storage gm._temp_:std var1[-1] set from entity 91bb5-0-0-0-ffff transformation.translation[0]
+data modify entity 91bb5-0-0-0-ffff transformation set from storage gm._temp_:std var1
 data modify storage gm:io out set from entity 91bb5-0-0-0-ffff transformation.translation[0]
 return run data get storage gm:io out
 

--- a/data/gm/functions/negate.mcfunction
+++ b/data/gm/functions/negate.mcfunction
@@ -1,11 +1,26 @@
+#> gm:negate
+#
+# ## Gets the negative of a value
+#
+# Equivalent to `-x`
+#
+# ---
+# @context any
+# @api
+# @macro
+#   x: float | double
+#      The value to negate
+# @output
+#   storage gm:io
+#      out: int | double | "fail"
+
 data modify storage gm:io out set value "fail"
-$data modify storage gm:temp var1 set value $(x)
-$data modify storage gm:temp tv2p set value $(x)
-data modify storage gm:temp tv2p set string storage gm:temp tv2p 0 1
-execute if data storage gm:temp {tv2p:"-"} run data modify storage gm:temp var1 set string storage gm:temp var1 1
-execute if data storage gm:temp {tv2p:"-"} run data modify storage gm:temp v2p set value ""
-execute unless data storage gm:temp {tv2p:"-"} run data modify storage gm:temp v2p set value "-"
-return run function gm:zzz/negate_handling with storage gm:temp
+$data modify storage gm._temp_:std var1 set value $(x)
+data modify storage gm._temp_:std tv2p set string storage gm._temp_:std var1 0 1
+execute if data storage gm._temp_:std {tv2p:"-"} run data modify storage gm._temp_:std var1 set string storage gm._temp_:std var1 1
+execute if data storage gm._temp_:std {tv2p:"-"} run data modify storage gm._temp_:std v2p set value ""
+execute unless data storage gm._temp_:std {tv2p:"-"} run data modify storage gm._temp_:std v2p set value "-"
+return run function gm:zzz/negate_handling with storage gm._temp_:std
 
 return fail
 $tp invalid-input $(x) 0 0

--- a/data/gm/functions/reciprocal.mcfunction
+++ b/data/gm/functions/reciprocal.mcfunction
@@ -1,3 +1,19 @@
+#> gm:reciprocal
+#
+# ## Gets the reciprocal of a value
+#
+# Equivalent to `1/x`
+#
+# ---
+# @context any
+# @api
+# @macro
+#   x: float | double
+#      The value to get the reciprocal of
+# @output
+#   storage gm:io
+#      out: float | "fail"
+
 data modify storage gm:io out set value "fail"
 $data modify entity 91bb5-0-0-0-ffff transformation set value [1f,0f,0f,0f,0f,1f,0f,0f,0f,0f,1f,0f,0f,0f,0f,$(x)f]
 data modify storage gm:io out set from entity 91bb5-0-0-0-ffff transformation.scale[0]

--- a/data/gm/functions/sin.mcfunction
+++ b/data/gm/functions/sin.mcfunction
@@ -1,3 +1,21 @@
+#> gm:sin
+#
+# ## Gets the sine of a value
+#
+# Equivalent to `sin(x)`
+#
+# Outputs from `-1` to `+1`
+#
+# ---
+# @context any
+# @api
+# @macro
+#   x: float | double
+#      The value to get the sine of in degrees
+# @output
+#   storage gm:io
+#      out: double | "fail"
+
 data modify storage gm:io out set value "fail"
 $execute rotated $(x) 0 positioned 0.0 0.0 0.0 positioned ^ ^ ^-1 as 91bb5-0-0-0-ffff run return run function gm:zzz/sin_handling
 

--- a/data/gm/functions/sqrt.mcfunction
+++ b/data/gm/functions/sqrt.mcfunction
@@ -1,5 +1,30 @@
+#> gm:sqrt
+#
+# ## Gets the square root of a value
+#
+# Equivalent to `√x`
+#
+# Uses a recursive algorithm to accurately approximate the square root of `x`.
+#
+# # Fails
+# Will fail if `x < 0`
+#
+# # Unstable
+# In ***very rare*** cases, can run forever. If you find this occuring,
+# please report it at https://github.com/gibbsly/gm/issues
+#
+# ---
+# @context any
+# @api
+# @macro
+#   x: float | double
+#      The value to get the square root of
+# @output
+#   storage gm:io
+#      out: float | "fail"
+
 data modify storage gm:io out set value "fail"
-$data merge storage gm:temp {var1:$(x), var2:1, var3:[0d,0d,0d,0d,0d,1d,0d,0d,0d,0d,1d,0d,0d,0d,0d,2d], var4:[0f,0f,0f,$(x)f,0f,1f,0f,0f,0f,0f,1f,0f,0f,0f,0f,0f]}
+$data merge storage gm._temp_:std {var1:$(x), var2:1, var3:[0d,0d,0d,0d,0d,1d,0d,0d,0d,0d,1d,0d,0d,0d,0d,2d], var4:[0f,0f,0f,$(x)f,0f,1f,0f,0f,0f,0f,1f,0f,0f,0f,0f,0f]}
 $return run function gm:zzz/sqrt_handling {var1:$(x), var2:1}
 
 return fail

--- a/data/gm/functions/square.mcfunction
+++ b/data/gm/functions/square.mcfunction
@@ -1,8 +1,24 @@
+#> gm:square
+#
+# ## Gets the square of a value
+#
+# Equivalent to `x²`
+#
+# ---
+# @context any
+# @api
+# @macro
+#   x: float | double
+#      The value to square
+# @output
+#   storage gm:io
+#      out: float | "fail"
+
 data modify storage gm:io out set value "fail"
-$data modify storage gm:temp var1 set value [0f,0f,0f,$(x)f,0f,1f,0f,0f,0f,0f,1f,0f,0f,0f,0f,1f]
+$data modify storage gm._temp_:std var1 set value [0f,0f,0f,$(x)f,0f,1f,0f,0f,0f,0f,1f,0f,0f,0f,0f,1f]
 $data modify entity 91bb5-0-0-0-ffff transformation set value [0f,0f,0f,1f,0f,1f,0f,0f,0f,0f,1f,0f,0f,0f,0f,$(x)f]
-data modify storage gm:temp var1[-1] set from entity 91bb5-0-0-0-ffff transformation.translation[0]
-data modify entity 91bb5-0-0-0-ffff transformation set from storage gm:temp var1
+data modify storage gm._temp_:std var1[-1] set from entity 91bb5-0-0-0-ffff transformation.translation[0]
+data modify entity 91bb5-0-0-0-ffff transformation set from storage gm._temp_:std var1
 data modify storage gm:io out set from entity 91bb5-0-0-0-ffff transformation.translation[0]
 return run data get storage gm:io out
 

--- a/data/gm/functions/subtract.mcfunction
+++ b/data/gm/functions/subtract.mcfunction
@@ -1,14 +1,34 @@
+#> gm:subtract
+#
+# ## Gets the difference between two values
+#
+# Equivalent to `x - y`
+#
+# Has a max output range of -20000000 to 19999999, outside of which, this function returns 0
+#
+# ---
+# @context any
+# @api
+# @macro
+#   x: float | double
+#      The value to be subtracted from
+#   y: float | double
+#      The value to subtract
+# @output
+#   storage gm:io
+#      out: double | "fail"
+
 data modify storage gm:io out set value "fail"
-$data modify storage gm:temp var1 set value $(x)
-$data modify storage gm:temp var2 set value $(y)
-$data modify storage gm:temp tv2p set value $(y)
-data modify storage gm:temp tv2p set string storage gm:temp tv2p 0 1
-execute if data storage gm:temp {tv2p:"-"} run data modify storage gm:temp var2 set string storage gm:temp var2 1
-execute if data storage gm:temp {tv2p:"-"} run data modify storage gm:temp v2dt set string storage gm:temp var2 -1
-execute if data storage gm:temp {tv2p:"-"} if data storage gm:temp {v2dt:"d"} run data modify storage gm:temp var2 set string storage gm:temp var2 0 -1
-execute if data storage gm:temp {tv2p:"-"} run data modify storage gm:temp v2p set value ""
-execute unless data storage gm:temp {tv2p:"-"} run data modify storage gm:temp v2p set value "-"
-return run function gm:zzz/subtract_handling with storage gm:temp
+$data modify storage gm._temp_:std var1 set value $(x)
+$data modify storage gm._temp_:std var2 set value $(y)
+$data modify storage gm._temp_:std tv2p set value $(y)
+data modify storage gm._temp_:std tv2p set string storage gm._temp_:std tv2p 0 1
+execute if data storage gm._temp_:std {tv2p:"-"} run data modify storage gm._temp_:std var2 set string storage gm._temp_:std var2 1
+execute if data storage gm._temp_:std {tv2p:"-"} run data modify storage gm._temp_:std v2dt set string storage gm._temp_:std var2 -1
+execute if data storage gm._temp_:std {tv2p:"-"} if data storage gm._temp_:std {v2dt:"d"} run data modify storage gm._temp_:std var2 set string storage gm._temp_:std var2 0 -1
+execute if data storage gm._temp_:std {tv2p:"-"} run data modify storage gm._temp_:std v2p set value ""
+execute unless data storage gm._temp_:std {tv2p:"-"} run data modify storage gm._temp_:std v2p set value "-"
+return run function gm:zzz/subtract_handling with storage gm._temp_:std
 
 return fail
 $tp invalid-input $(x) $(y) 0

--- a/data/gm/functions/tan.mcfunction
+++ b/data/gm/functions/tan.mcfunction
@@ -1,3 +1,21 @@
+#> gm:tan
+#
+# ## Gets the tangent of a value
+#
+# Equivalent to `tan(x)`
+#
+# Can return `Infinityf` as the value approaches infinity
+#
+# ---
+# @context any
+# @api
+# @macro
+#   x: float | double
+#      The value to get the cosine of in degrees
+# @output
+#   storage gm:io
+#      out: float | "fail"
+
 data modify storage gm:io out set value "fail"
 $execute rotated $(x) 0 positioned 0.0 0.0 0.0 positioned ^ ^ ^-1 as 91bb5-0-0-0-ffff run return run function gm:zzz/tan_handling
 

--- a/data/gm/functions/zzz/arctan/add_one.mcfunction
+++ b/data/gm/functions/zzz/arctan/add_one.mcfunction
@@ -1,3 +1,11 @@
+#> gm:zzz/arctan/add_one
+#
+# Used during arctan to add 1 to tan²(θ). Also converts var5 from a float to a double
+#
+# ---
+# @context any
+# @within gm:arctan
+
 $execute positioned ~ 1 ~ run tp 91bb5-0-0-0-ffff ~ ~$(var5) ~
-data modify storage gm:temp var6 set from entity 91bb5-0-0-0-ffff Pos[1]
-$data modify storage gm:temp var5 set value $(var5)d
+data modify storage gm._temp_:std var6 set from entity 91bb5-0-0-0-ffff Pos[1]
+$data modify storage gm._temp_:std var5 set value $(var5)d

--- a/data/gm/functions/zzz/arctan/negate_val.mcfunction
+++ b/data/gm/functions/zzz/arctan/negate_val.mcfunction
@@ -1,3 +1,11 @@
-$data modify storage gm:temp var1 set value [0f,0f,0f,$(var1)f,0f,1f,0f,0f,0f,0f,1f,0f,0f,0f,0f,-1f]
-data modify entity 91bb5-0-0-0-ffff transformation set from storage gm:temp var1
-data modify storage gm:temp var1 set from entity 91bb5-0-0-0-ffff transformation.translation[0]
+#> gm:zzz/arctan/negate_val
+#
+# Negates var1
+#
+# ---
+# @context any
+# @within gm:arctan
+
+$data modify storage gm._temp_:std var1 set value [0f,0f,0f,$(var1)f,0f,1f,0f,0f,0f,0f,1f,0f,0f,0f,0f,-1f]
+data modify entity 91bb5-0-0-0-ffff transformation set from storage gm._temp_:std var1
+data modify storage gm._temp_:std var1 set from entity 91bb5-0-0-0-ffff transformation.translation[0]

--- a/data/gm/functions/zzz/cos_handling.mcfunction
+++ b/data/gm/functions/zzz/cos_handling.mcfunction
@@ -1,3 +1,13 @@
+#> gm:zzz/cos_handling
+#
+# Gets cos(θ)
+#
+# Must be called AS 91bb5-0-0-0-ffff
+#
+# ---
+# @context gm.math_entity
+# @within gm:cos
+
 tp @s ~ ~ ~
 data modify storage gm:io out set from entity @s Pos[2]
 tp @s 29999999 0 91665

--- a/data/gm/functions/zzz/distance_handling.mcfunction
+++ b/data/gm/functions/zzz/distance_handling.mcfunction
@@ -1,3 +1,11 @@
+#> gm:zzz/distance_handling
+#
+# Finds distance value of `(Δx, Δy, Δz)`
+#
+# ---
+# @context any
+# @internal
+
 $data modify entity 91bb5-0-0-0-ffff transformation set value [$(x)f,0f,0f,0f,$(y)f,0f,0f,0f,$(z)f,0f,0f,0f,0f,0f,0f,1f]
 data modify storage gm:io out set from entity 91bb5-0-0-0-ffff transformation.scale[0]
 return run data get storage gm:io out

--- a/data/gm/functions/zzz/divide_array.mcfunction
+++ b/data/gm/functions/zzz/divide_array.mcfunction
@@ -1,11 +1,19 @@
-$data modify storage gm:divide array set value $(array)
+#> gm:zzz/divide_array
+#
+# Handles the division of array by divisor
+#
+# ---
+# @context any
+# @internal
 
-data modify storage gm:divide 1 set from storage gm:divide array[0]
-data modify storage gm:divide 2 set from storage gm:divide array[1]
-data modify storage gm:divide 3 set from storage gm:divide array[2]
-$data modify storage gm:divide divisor set value $(divisor)
+$data modify storage gm._temp_:divide array set value $(array)
+
+data modify storage gm._temp_:divide 1 set from storage gm._temp_:divide array[0]
+data modify storage gm._temp_:divide 2 set from storage gm._temp_:divide array[1]
+data modify storage gm._temp_:divide 3 set from storage gm._temp_:divide array[2]
+$data modify storage gm._temp_:divide divisor set value $(divisor)
 data modify storage gm:io out set value []
 
-execute if data storage gm:divide array[2] run return run function gm:zzz/divide_array/3 with storage gm:divide
-execute if data storage gm:divide array[1] run return run function gm:zzz/divide_array/2 with storage gm:divide
-execute if data storage gm:divide array[0] run return run function gm:zzz/divide_array/1 with storage gm:divide
+execute if data storage gm._temp_:divide array[2] run return run function gm:zzz/divide_array/3 with storage gm._temp_:divide
+execute if data storage gm._temp_:divide array[1] run return run function gm:zzz/divide_array/2 with storage gm._temp_:divide
+execute if data storage gm._temp_:divide array[0] run return run function gm:zzz/divide_array/1 with storage gm._temp_:divide

--- a/data/gm/functions/zzz/divide_array/1.mcfunction
+++ b/data/gm/functions/zzz/divide_array/1.mcfunction
@@ -1,3 +1,9 @@
+#> gm:zzz/divide_array/1
+#
+# ---
+# @context any
+# @within gm:zzz/divide_array
+
 $data modify entity 91bb5-0-0-0-ffff transformation set value [0f,0f,0f,$(1)f,0f,0f,0f,0f,0f,0f,0f,0f,0f,0f,0f,$(divisor)f]
 data modify storage gm:io out append from entity 91bb5-0-0-0-ffff transformation.translation[]
 data remove storage gm:io out[-1]

--- a/data/gm/functions/zzz/divide_array/2.mcfunction
+++ b/data/gm/functions/zzz/divide_array/2.mcfunction
@@ -1,3 +1,9 @@
+#> gm:zzz/divide_array/2
+#
+# ---
+# @context any
+# @within gm:zzz/divide_array
+
 $data modify entity 91bb5-0-0-0-ffff transformation set value [0f,0f,0f,$(1)f,0f,0f,0f,$(2)f,0f,0f,0f,0f,0f,0f,0f,$(divisor)f]
 data modify storage gm:io out append from entity 91bb5-0-0-0-ffff transformation.translation[]
 data remove storage gm:io out[-1]

--- a/data/gm/functions/zzz/divide_array/3.mcfunction
+++ b/data/gm/functions/zzz/divide_array/3.mcfunction
@@ -1,3 +1,9 @@
+#> gm:zzz/divide_array/3
+#
+# ---
+# @context any
+# @within gm:zzz/divide_array
+
 $data modify entity 91bb5-0-0-0-ffff transformation set value [0f,0f,0f,$(1)f,0f,0f,0f,$(2)f,0f,0f,0f,$(3)f,0f,0f,0f,$(divisor)f]
 data modify storage gm:io out append from entity 91bb5-0-0-0-ffff transformation.translation[]
 return run data get storage gm:io out

--- a/data/gm/functions/zzz/divide_handling.mcfunction
+++ b/data/gm/functions/zzz/divide_handling.mcfunction
@@ -1,3 +1,12 @@
+#> gm:zzz/divide_handling
+#
+# Handles the division of var1 by var2
+#
+# ---
+# @context any
+# @internal
+
+
 $data modify entity 91bb5-0-0-0-ffff transformation set value [0f,0f,0f,$(var1)f,0f,1f,0f,0f,0f,0f,1f,0f,0f,0f,0f,$(var2)f]
 data modify storage gm:io out set from entity 91bb5-0-0-0-ffff transformation.translation[0]
 return run data get storage gm:io out

--- a/data/gm/functions/zzz/get_data_type.mcfunction
+++ b/data/gm/functions/zzz/get_data_type.mcfunction
@@ -1,10 +1,18 @@
-$data modify storage gm:check string append value $(value)
-$function gm:zzz/get_data_type/number_check {value:$(value)}
-$data modify storage gm:check array append value $(value)
-$data modify storage gm:check object append value $(value)
+#> gm:zzz/get_data_type
+#
+# Gets the datatype of value
+#
+# ---
+# @context any
+# @internal
 
-execute if data storage gm:check number[1] run return 1
-execute if data storage gm:check array[1] run return 2
-execute if data storage gm:check object[1] run return 3
-execute if data storage gm:check string[1] run return 4
+$data modify storage gm._temp_:check string append value $(value)
+$function gm:zzz/get_data_type/number_check {value:$(value)}
+$data modify storage gm._temp_:check array append value $(value)
+$data modify storage gm._temp_:check object append value $(value)
+
+execute if data storage gm._temp_:check number[1] run return 1
+execute if data storage gm._temp_:check array[1] run return 2
+execute if data storage gm._temp_:check object[1] run return 3
+execute if data storage gm._temp_:check string[1] run return 4
 return fail

--- a/data/gm/functions/zzz/get_data_type/number_check.mcfunction
+++ b/data/gm/functions/zzz/get_data_type/number_check.mcfunction
@@ -1,1 +1,8 @@
-$data modify storage gm:check number append value $(value)d
+#> gm:zzz/get_data_type/number_check
+#
+# Checks any number type as if it were a double
+#
+# ---
+# @context any
+# @internal
+$data modify storage gm._temp_:check number append value $(value)d

--- a/data/gm/functions/zzz/get_distance.mcfunction
+++ b/data/gm/functions/zzz/get_distance.mcfunction
@@ -1,41 +1,49 @@
-data modify storage gm:temp dist set value {}
+#> gm:zzz/get_distance
+#
+# ## This function is unused
+#
+# ---
+# @context none
+# @private
+
+data modify storage gm._temp_:std dist set value {}
 
 #setup
-$data modify storage gm:temp v2p set value $(x)
-data modify storage gm:temp var1 set value {}
-data modify storage gm:temp var1.x1 set from storage gm:temp v2p[0]
-data modify storage gm:temp var1.y1 set from storage gm:temp v2p[1]
-data modify storage gm:temp var1.z1 set from storage gm:temp v2p[2]
-$data modify storage gm:temp v2p set value $(x)
-data modify storage gm:temp var1.x2 set from storage gm:temp v2p[0]
-data modify storage gm:temp var1.y2 set from storage gm:temp v2p[1]
-data modify storage gm:temp var1.z2 set from storage gm:temp v2p[2]
+$data modify storage gm._temp_:std v2p set value $(x)
+data modify storage gm._temp_:std var1 set value {}
+data modify storage gm._temp_:std var1.x1 set from storage gm._temp_:std v2p[0]
+data modify storage gm._temp_:std var1.y1 set from storage gm._temp_:std v2p[1]
+data modify storage gm._temp_:std var1.z1 set from storage gm._temp_:std v2p[2]
+$data modify storage gm._temp_:std v2p set value $(x)
+data modify storage gm._temp_:std var1.x2 set from storage gm._temp_:std v2p[0]
+data modify storage gm._temp_:std var1.y2 set from storage gm._temp_:std v2p[1]
+data modify storage gm._temp_:std var1.z2 set from storage gm._temp_:std v2p[2]
 
 #x
-data modify storage gm:temp var2 set value {x:0,y:0}
-data modify storage gm:temp var2.x set from storage gm:temp var1.x1
-data modify storage gm:temp var2.y set from storage gm:temp var1.x2
-function gm:subtract with storage gm:temp var2
-data modify storage gm:temp tv2p set string storage gm:io out 0 1
-execute if data storage gm:temp {tv2p:"-"} run function gm:zzz/inverted_subtract with storage gm:temp var2
-data modify storage gm:temp dist.x set from storage gm:io out
+data modify storage gm._temp_:std var2 set value {x:0,y:0}
+data modify storage gm._temp_:std var2.x set from storage gm._temp_:std var1.x1
+data modify storage gm._temp_:std var2.y set from storage gm._temp_:std var1.x2
+function gm:subtract with storage gm._temp_:std var2
+data modify storage gm._temp_:std tv2p set string storage gm:io out 0 1
+execute if data storage gm._temp_:std {tv2p:"-"} run function gm:zzz/inverted_subtract with storage gm._temp_:std var2
+data modify storage gm._temp_:std dist.x set from storage gm:io out
 
 #y
-data modify storage gm:temp var2 set value {x:0,y:0}
-data modify storage gm:temp var2.x set from storage gm:temp var1.y1
-data modify storage gm:temp var2.y set from storage gm:temp var1.y2
-function gm:subtract with storage gm:temp var2
-data modify storage gm:temp tv2p set string storage gm:io out 0 1
-execute if data storage gm:temp {tv2p:"-"} run function gm:zzz/inverted_subtract with storage gm:temp var2
-data modify storage gm:temp dist.y set from storage gm:io out
+data modify storage gm._temp_:std var2 set value {x:0,y:0}
+data modify storage gm._temp_:std var2.x set from storage gm._temp_:std var1.y1
+data modify storage gm._temp_:std var2.y set from storage gm._temp_:std var1.y2
+function gm:subtract with storage gm._temp_:std var2
+data modify storage gm._temp_:std tv2p set string storage gm:io out 0 1
+execute if data storage gm._temp_:std {tv2p:"-"} run function gm:zzz/inverted_subtract with storage gm._temp_:std var2
+data modify storage gm._temp_:std dist.y set from storage gm:io out
 
 #z
-data modify storage gm:temp var2 set value {x:0,y:0}
-data modify storage gm:temp var2.x set from storage gm:temp var1.z1
-data modify storage gm:temp var2.y set from storage gm:temp var1.z2
-function gm:subtract with storage gm:temp var2
-data modify storage gm:temp tv2p set string storage gm:io out 0 1
-execute if data storage gm:temp {tv2p:"-"} run function gm:zzz/inverted_subtract with storage gm:temp var2
-data modify storage gm:temp dist.z set from storage gm:io out
+data modify storage gm._temp_:std var2 set value {x:0,y:0}
+data modify storage gm._temp_:std var2.x set from storage gm._temp_:std var1.z1
+data modify storage gm._temp_:std var2.y set from storage gm._temp_:std var1.z2
+function gm:subtract with storage gm._temp_:std var2
+data modify storage gm._temp_:std tv2p set string storage gm:io out 0 1
+execute if data storage gm._temp_:std {tv2p:"-"} run function gm:zzz/inverted_subtract with storage gm._temp_:std var2
+data modify storage gm._temp_:std dist.z set from storage gm:io out
 
-function gm:zzz/distance_handling with storage gm:temp dist
+function gm:zzz/distance_handling with storage gm._temp_:std dist

--- a/data/gm/functions/zzz/inverse_trig/get_opposite.mcfunction
+++ b/data/gm/functions/zzz/inverse_trig/get_opposite.mcfunction
@@ -1,7 +1,15 @@
-data modify storage gm:temp var1[-1] set from entity 91bb5-0-0-0-ffff transformation.translation[0]
-data modify entity 91bb5-0-0-0-ffff transformation set from storage gm:temp var1
-data modify storage gm:temp var1 set from entity 91bb5-0-0-0-ffff transformation.translation[0]
-function gm:zzz/inverse_trig/range_check with storage gm:temp
-execute if data storage gm:temp {v1sqp:"-"} run return fail
-function gm:sqrt with storage gm:temp
+#> gm:zzz/inverse_trig/get_opposite
+#
+# Used to convert sin(θ) to cos(θ) or vice versa
+#
+# ---
+# @context any
+# @internal
+
+data modify storage gm._temp_:std var1[-1] set from entity 91bb5-0-0-0-ffff transformation.translation[0]
+data modify entity 91bb5-0-0-0-ffff transformation set from storage gm._temp_:std var1
+data modify storage gm._temp_:std var1 set from entity 91bb5-0-0-0-ffff transformation.translation[0]
+function gm:zzz/inverse_trig/range_check with storage gm._temp_:std
+execute if data storage gm._temp_:std {v1sqp:"-"} run return fail
+function gm:sqrt with storage gm._temp_:std
 return 1

--- a/data/gm/functions/zzz/inverse_trig/handling.mcfunction
+++ b/data/gm/functions/zzz/inverse_trig/handling.mcfunction
@@ -1,3 +1,13 @@
+#> gm:zzz/inverse_trig/handling
+#
+# Uses (var1, var2) to find the angle to (0, 0)
+#
+# Must be called AS 91bb5-0-0-0-ffff
+#
+# ---
+# @context gm.math_entity
+# @internal
+
 $data modify entity @s Pos set value [$(var1)d,0.0d,$(var2)d]
 execute at @s run tp @s ~ ~ ~ facing 0.0 0.0 0.0
 data modify storage gm:io out set from entity @s Rotation[0]

--- a/data/gm/functions/zzz/inverse_trig/negate_val.mcfunction
+++ b/data/gm/functions/zzz/inverse_trig/negate_val.mcfunction
@@ -1,3 +1,11 @@
-$data modify storage gm:temp var1 set value [0f,0f,0f,$(var2)f,0f,1f,0f,0f,0f,0f,1f,0f,0f,0f,0f,-1f]
-data modify entity 91bb5-0-0-0-ffff transformation set from storage gm:temp var1
-data modify storage gm:temp var2 set from entity 91bb5-0-0-0-ffff transformation.translation[0]
+#> gm:zzz/inverse_trig/negate_val
+#
+# Negates var2
+#
+# ---
+# @context any
+# @internal
+
+$data modify storage gm._temp_:std var1 set value [0f,0f,0f,$(var2)f,0f,1f,0f,0f,0f,0f,1f,0f,0f,0f,0f,-1f]
+data modify entity 91bb5-0-0-0-ffff transformation set from storage gm._temp_:std var1
+data modify storage gm._temp_:std var2 set from entity 91bb5-0-0-0-ffff transformation.translation[0]

--- a/data/gm/functions/zzz/inverse_trig/range_check.mcfunction
+++ b/data/gm/functions/zzz/inverse_trig/range_check.mcfunction
@@ -1,3 +1,14 @@
+#> gm:zzz/inverse_trig/range_check
+#
+# Subtracts var1 from 1, saves it to x, and saves the polarity of x to v1sqp (var1 squared polarity)
+#
+# This is later used to check if sin(θ) or cos(θ) is between -1 and 1
+# (Because `1 - sin²(θ)` or `1 - cos²(θ)` will always be greater than 0 if it's valid)
+#
+# ---
+# @context any
+# @internal
+
 $execute positioned ~ 1 ~ run tp 91bb5-0-0-0-ffff ~ ~-$(var1) ~
-data modify storage gm:temp x set from entity 91bb5-0-0-0-ffff Pos[1]
-data modify storage gm:temp v1sqp set string storage gm:temp x 0 1
+data modify storage gm._temp_:std x set from entity 91bb5-0-0-0-ffff Pos[1]
+data modify storage gm._temp_:std v1sqp set string storage gm._temp_:std x 0 1

--- a/data/gm/functions/zzz/load.mcfunction
+++ b/data/gm/functions/zzz/load.mcfunction
@@ -1,2 +1,15 @@
+#> gm:zzz/load
+#
+# ## The load function for GM
+#
+# ---
+# @context root
+# @internal
+# @handles #minecraft:load
+#define storage gm:io IO storage
+#define storage gm._temp_:std Standard transient storage
+#define storage gm._temp_:divide Division specific transient storage
+#define storage gm._temp_:check Type checking specific transient storage
+
 forceload add 29999999 91665
-execute unless entity 91bb5-0-0-0-ffff run summon item_display 29999999 0 91665 {UUID:[I;596917,0,0,65535],CustomName:'"mc-floating-point-arithmetic entity"'}
+execute unless entity 91bb5-0-0-0-ffff run summon item_display 29999999 0 91665 {UUID:[I;596917,0,0,65535],CustomName:'"gm.math_entity"'}

--- a/data/gm/functions/zzz/negate_handling.mcfunction
+++ b/data/gm/functions/zzz/negate_handling.mcfunction
@@ -1,2 +1,10 @@
+#> gm:zzz/negate_handling
+#
+# Negates using polarity variable
+#
+# ---
+# @context any
+# @within gm:negate
+
 $data modify storage gm:io out set value $(v2p)$(var1)
 return run data get storage gm:io out

--- a/data/gm/functions/zzz/sin_handling.mcfunction
+++ b/data/gm/functions/zzz/sin_handling.mcfunction
@@ -1,3 +1,13 @@
+#> gm:zzz/sin_handling
+#
+# Gets sin(θ)
+#
+# Must be called AS 91bb5-0-0-0-ffff
+#
+# ---
+# @context gm.math_entity
+# @within gm:sin
+
 tp @s ~ ~ ~
 data modify storage gm:io out set from entity @s Pos[0]
 tp @s 29999999 0 91665

--- a/data/gm/functions/zzz/sqrt/positive_subtract.mcfunction
+++ b/data/gm/functions/zzz/sqrt/positive_subtract.mcfunction
@@ -1,0 +1,10 @@
+#> gm:zzz/sqrt/positive_subtract
+#
+# Subtracts var2 from var1. Doesn't have to check for polarity, because var1 and var2 will always be greater than 0
+# Also subtracts the threshold
+#
+# ---
+# @context any
+# @within gm:zzz/sqrt_handling
+$execute positioned ~ $(var1) ~ positioned ~ ~-0.000000001 ~ run tp 91bb5-0-0-0-ffff 29999999 ~-$(var2) 91665
+data modify storage gm._temp_:std v1m2p set string entity 91bb5-0-0-0-ffff Pos[1] 0 1

--- a/data/gm/functions/zzz/sqrt_handling.mcfunction
+++ b/data/gm/functions/zzz/sqrt_handling.mcfunction
@@ -1,14 +1,26 @@
-$execute positioned ~ $(var1) ~ run tp 91bb5-0-0-0-ffff 29999999 ~$(var2) 91665
-data modify storage gm:temp var3[3] set from entity 91bb5-0-0-0-ffff Pos[1]
-data modify entity 91bb5-0-0-0-ffff transformation set from storage gm:temp var3
-data modify storage gm:temp var1 set from entity 91bb5-0-0-0-ffff transformation.translation[0]
-data modify storage gm:temp var4[-1] set from storage gm:temp var1
-data modify entity 91bb5-0-0-0-ffff transformation set from storage gm:temp var4
-data modify storage gm:temp var2 set from entity 91bb5-0-0-0-ffff transformation.translation[0]
+#> gm:zzz/sqrt_handling
+#
+# Main sqrt loop
+# 1. var1 += var2
+# 2. var1 /= 2
+# 3. var2 = init / var1
+# 4. If accuracy threshold not met, loop again
+#
+# ---
+# @context any
+# @within gm:sqrt
 
-function gm:zzz/sqrt_handling/positive_subtract with storage gm:temp
-execute unless data storage gm:temp {v1m2p:"-"} run return run function gm:zzz/sqrt_handling with storage gm:temp
+$execute positioned ~ $(var1) ~ run tp 91bb5-0-0-0-ffff 29999999 ~$(var2) 91665
+data modify storage gm._temp_:std var3[3] set from entity 91bb5-0-0-0-ffff Pos[1]
+data modify entity 91bb5-0-0-0-ffff transformation set from storage gm._temp_:std var3
+data modify storage gm._temp_:std var1 set from entity 91bb5-0-0-0-ffff transformation.translation[0]
+data modify storage gm._temp_:std var4[-1] set from storage gm._temp_:std var1
+data modify entity 91bb5-0-0-0-ffff transformation set from storage gm._temp_:std var4
+data modify storage gm._temp_:std var2 set from entity 91bb5-0-0-0-ffff transformation.translation[0]
+
+function gm:zzz/sqrt/positive_subtract with storage gm._temp_:std
+execute unless data storage gm._temp_:std {v1m2p:"-"} run return run function gm:zzz/sqrt_handling with storage gm._temp_:std
 
 tp 91bb5-0-0-0-ffff 29999999 0 91665
-data modify storage gm:io out set from storage gm:temp var1
+data modify storage gm:io out set from storage gm._temp_:std var1
 return run data get storage gm:io out

--- a/data/gm/functions/zzz/sqrt_handling/positive_subtract.mcfunction
+++ b/data/gm/functions/zzz/sqrt_handling/positive_subtract.mcfunction
@@ -1,2 +1,0 @@
-$execute positioned ~ $(var1) ~ positioned ~ ~-0.000001 ~ run tp 91bb5-0-0-0-ffff 29999999 ~-$(var2) 91665
-data modify storage gm:temp v1m2p set string entity 91bb5-0-0-0-ffff Pos[1] 0 1

--- a/data/gm/functions/zzz/subtract_handling.mcfunction
+++ b/data/gm/functions/zzz/subtract_handling.mcfunction
@@ -1,3 +1,11 @@
+#> gm:zzz/subtract_handling
+#
+# Handler for subtraction. Accepts a polarity macro.
+#
+# ---
+# @context any
+# @within gm:subtract
+
 $execute positioned ~ $(var1) ~ run tp 91bb5-0-0-0-ffff 29999999 ~$(v2p)$(var2) 91665
 data modify storage gm:io out set from entity 91bb5-0-0-0-ffff Pos[1]
 tp 91bb5-0-0-0-ffff 29999999 0 91665

--- a/data/gm/functions/zzz/tan_handling.mcfunction
+++ b/data/gm/functions/zzz/tan_handling.mcfunction
@@ -1,7 +1,17 @@
+#> gm:zzz/tan_handling
+#
+# Gets tan(θ)
+#
+# Must be called AS 91bb5-0-0-0-ffff
+#
+# ---
+# @context gm.math_entity
+# @within gm:tan
+
 tp @s ~ ~ ~
-data modify storage gm:temp var1 set from entity @s Pos[0]
+data modify storage gm._temp_:std var1 set from entity @s Pos[0]
 tp @s ^ ^ ^2
-data modify storage gm:temp var2 set from entity @s Pos[2]
+data modify storage gm._temp_:std var2 set from entity @s Pos[2]
 tp @s 29999999 0 91665
-function gm:zzz/divide_handling with storage gm:temp
+function gm:zzz/divide_handling with storage gm._temp_:std
 return run data get storage gm:io out


### PR DESCRIPTION
# The Suggestion
#7 
# Implementation description
- Fixes #7
- Added IMP-DOC to all functions
  - This includes `@macro` tag
- Implemented IMP-CORE adjacent storage names
  - Only IMP-CORE adjacent because certain namespacing schemes lead to overly excessive name bloat, and thus were shortened.
- Renamed math entity
- Small file location shift in sqrt section
- Every function was thoroughly tested following implementation to ensure storage name changes did not break anything
  - All functions still function normally