### PR TITLE
Add rounding functions + small fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,3 +95,21 @@ also outputs sin to `storage gm._temp_:std var1` and cos to `storage gm._temp_:s
 > does `tan⁻¹(x)`
 
 `-90 ≤ tan⁻¹(x) ≤ 90`
+
+### `gm:round`
+
+> does `round(x)`
+
+Rounds x to the nearest integer. `0.5` will round up
+
+### `gm:floor`
+
+> does `floor(x)`
+
+Rounds x down to the nearest integer
+
+### `gm:ceil`
+
+> does `ceil(x)`
+
+Rounds x up to the nearest integer

--- a/data/gm/functions/arctan2.mcfunction
+++ b/data/gm/functions/arctan2.mcfunction
@@ -2,7 +2,7 @@
 #
 # ## Gets the arctangent of a point
 #
-# Equivalent to `atan(y, x)`
+# Equivalent to `atan2(y, x)`
 # 
 # Measures the counterclockwise angle from the positive x axis to the point `(x, y)`.
 #

--- a/data/gm/functions/ceil.mcfunction
+++ b/data/gm/functions/ceil.mcfunction
@@ -1,0 +1,30 @@
+#> gm:ceil
+#
+# ## Gets the ceil of a value
+#
+# Rounds up to the nearest whole integer
+#
+# Has a max output range of -20000000 to 19999999, outside of which, this function returns 0
+#
+# ---
+# @context any
+# @api
+# @macro
+#   x: float | double
+#      The value to ceil
+# @output
+#   storage gm:io
+#      out: double | "fail"
+
+data modify storage gm:io out set value "fail"
+$data modify storage gm._temp_:std var1 set value [0d,0d,0d,$(x)d,0d,1d,0d,0d,0d,0d,1d,0d,0d,0d,0d,-1d]
+data modify entity 91bb5-0-0-0-ffff transformation set from storage gm._temp_:std var1
+data modify storage gm._temp_:std x set from entity 91bb5-0-0-0-ffff transformation.translation[0]
+function gm:floor with storage gm._temp_:std
+data modify storage gm._temp_:std var1[3] set from storage gm:io out
+data modify entity 91bb5-0-0-0-ffff transformation set from storage gm._temp_:std var1
+data modify storage gm:io out set from entity 91bb5-0-0-0-ffff transformation.translation[0]
+return run data get storage gm:io out
+
+return fail
+$tp invalid-input $(x) 0 0

--- a/data/gm/functions/floor.mcfunction
+++ b/data/gm/functions/floor.mcfunction
@@ -1,0 +1,26 @@
+#> gm:floor
+#
+# ## Gets the floor of a value
+#
+# Rounds down to the nearest whole integer
+#
+# Has a max output range of -20000000 to 19999999, outside of which, this function returns 0
+#
+# ---
+# @context any
+# @api
+# @macro
+#   x: float | double
+#      The value to floor
+# @output
+#   storage gm:io
+#      out: double | "fail"
+
+data modify storage gm:io out set value "fail"
+$execute positioned ~ $(x) ~ align y run tp 91bb5-0-0-0-ffff ~ ~ ~
+data modify storage gm:io out set from entity 91bb5-0-0-0-ffff Pos[1]
+tp 91bb5-0-0-0-ffff 29999999 0 91665
+return run data get storage gm:io out
+
+return fail
+$tp invalid-input $(x) 0 0

--- a/data/gm/functions/round.mcfunction
+++ b/data/gm/functions/round.mcfunction
@@ -1,0 +1,26 @@
+#> gm:round
+#
+# ## Gets the rounded value
+#
+# Rounds to the nearest whole integer
+#
+# Has a max output range of -20000000 to 19999999, outside of which, this function returns 0
+#
+# ---
+# @context any
+# @api
+# @macro
+#   x: float | double
+#      The value to round
+# @output
+#   storage gm:io
+#      out: double | "fail"
+
+data modify storage gm:io out set value "fail"
+$execute positioned ~ $(x) ~ positioned ~ ~0.5 ~ align y run tp 91bb5-0-0-0-ffff ~ ~ ~
+data modify storage gm:io out set from entity 91bb5-0-0-0-ffff Pos[1]
+tp 91bb5-0-0-0-ffff 29999999 0 91665
+return run data get storage gm:io out
+
+return fail
+$tp invalid-input $(x) 0 0

--- a/data/gm/functions/zzz/load.mcfunction
+++ b/data/gm/functions/zzz/load.mcfunction
@@ -10,6 +10,7 @@
 #define storage gm._temp_:std Standard transient storage
 #define storage gm._temp_:divide Division specific transient storage
 #define storage gm._temp_:check Type checking specific transient storage
+#define entity 91bb5-0-0-0-ffff
 
 forceload add 29999999 91665
 execute unless entity 91bb5-0-0-0-ffff run summon item_display 29999999 0 91665 {UUID:[I;596917,0,0,65535],CustomName:'"gm.math_entity"'}


### PR DESCRIPTION
# The Suggestion
Add the following functions:
- `round(x)`
- `floor(x)`
- `ceil(x)`
# Implementation description
- Added the functions
- Ensured same formatting and error checking to the original codebase
- Included IMP-DOC for new functions
- Updated README to add `gm:round`, `gm:floor`, `gm:ceil` to list of functions
# Additional changes
- Fix small typo in `gm:arctan2` IMP-DOC
- Define math entity in load