### PR TITLE
Fix issue with subtraction

### DIFF
--- a/data/gm/functions/subtract.mcfunction
+++ b/data/gm/functions/subtract.mcfunction
@@ -28,6 +28,7 @@ execute if data storage gm._temp_:std {tv2p:"-"} run data modify storage gm._tem
 execute if data storage gm._temp_:std {tv2p:"-"} if data storage gm._temp_:std {v2dt:"d"} run data modify storage gm._temp_:std var2 set string storage gm._temp_:std var2 0 -1
 execute if data storage gm._temp_:std {tv2p:"-"} run data modify storage gm._temp_:std v2p set value ""
 execute unless data storage gm._temp_:std {tv2p:"-"} run data modify storage gm._temp_:std v2p set value "-"
+function gm:zzz/convert_to_double with storage gm._temp_:std
 return run function gm:zzz/subtract_handling with storage gm._temp_:std
 
 return fail

--- a/data/gm/functions/zzz/convert_to_double.mcfunction
+++ b/data/gm/functions/zzz/convert_to_double.mcfunction
@@ -1,0 +1,9 @@
+#> gm:zzz/convert_to_double
+#
+# Converts var2 to a double
+#
+# ---
+# @context any
+# @within gm:subtract
+
+$data modify storage gm._temp_:std var2 set value $(var2)d


### PR DESCRIPTION
# The Problem
When exponent representation of a double or float was used, `gm:subtract` fails
# Solution description
Converting var2 from a string back to a double fixes this issue