### PR TITLE
Add modulo function

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ when specifying `x` as an array of numbers (will only divide up to the first 3 n
 
 outputs the resulting numbers in an array in the default output location and returns the length of the outputted array
 
+### `gm:modulo`
+
+> does `x % y`
+
+implementation of fmod. fails if y is 0
+
 ### `gm:distance`
 
 > gets the distance between `x` and `y`

--- a/data/gm/functions/modulo.mcfunction
+++ b/data/gm/functions/modulo.mcfunction
@@ -1,0 +1,47 @@
+#> gm:modulo
+#
+# ## Gets the modulo of two values
+#
+# Equivalent to `x % y`
+#
+# # Fails
+# Will fail if `y = 0`
+#
+# ---
+# @context any
+# @api
+# @macro
+#   x: float | double
+#      The numerator
+#   y: float | double
+#      The denominator
+# @output
+#   storage gm:io
+#      out: double | "fail"
+
+data modify storage gm:io out set value "fail"
+# divide by 0 check
+$data modify storage gm._temp_:std var1 set value $(y)f
+execute if data storage gm._temp_:std {var1:0f} run return fail
+# var1
+$data modify storage gm._temp_:std var1 set value $(x)f
+# var2
+$data modify entity 91bb5-0-0-0-ffff transformation set value [0f,0f,0f,$(x)f,0f,1f,0f,0f,0f,0f,1f,0f,0f,0f,0f,$(y)f]
+data modify storage gm._temp_:std var2 set from entity 91bb5-0-0-0-ffff transformation.translation[0]
+data modify storage gm._temp_:std tv2p set string storage gm._temp_:std var2 0 1
+execute if data storage gm._temp_:std {tv2p:"-"} run data modify storage gm._temp_:std var2 set string storage gm._temp_:std var2 1
+execute if data storage gm._temp_:std {tv2p:"-"} run data modify storage gm._temp_:std v2p set value "-"
+execute unless data storage gm._temp_:std {tv2p:"-"} run data modify storage gm._temp_:std v2p set value ""
+data modify storage gm._temp_:std var2 set string storage gm._temp_:std var2 0 -1
+function gm:zzz/convert_to_double with storage gm._temp_:std
+# var3
+$data modify entity 91bb5-0-0-0-ffff transformation set value [0f,0f,0f,1f,0f,1f,0f,0f,0f,0f,1f,0f,0f,0f,0f,$(y)f]
+data modify storage gm._temp_:std var3 set from entity 91bb5-0-0-0-ffff transformation.translation[0]
+# handling
+function gm:zzz/modulo/truncate with storage gm._temp_:std
+function gm:zzz/modulo/divide with storage gm._temp_:std
+function gm:zzz/convert_to_double with storage gm._temp_:std
+return run function gm:zzz/subtract_handling with storage gm._temp_:std
+
+return fail
+$tp invalid-input $(x) $(y) 0

--- a/data/gm/functions/zzz/convert_to_double.mcfunction
+++ b/data/gm/functions/zzz/convert_to_double.mcfunction
@@ -4,6 +4,6 @@
 #
 # ---
 # @context any
-# @within gm:subtract
+# @internal
 
 $data modify storage gm._temp_:std var2 set value $(var2)d

--- a/data/gm/functions/zzz/modulo/divide.mcfunction
+++ b/data/gm/functions/zzz/modulo/divide.mcfunction
@@ -1,0 +1,16 @@
+#> gm:zzz/modulo/divide
+#
+# Divides var2 by var3
+#
+# ---
+# @context any
+# @within gm:modulo
+
+say divide
+$data modify entity 91bb5-0-0-0-ffff transformation set value [0f,0f,0f,$(var2)f,0f,1f,0f,0f,0f,0f,1f,0f,0f,0f,0f,$(var3)f]
+data modify storage gm._temp_:std var2 set from entity 91bb5-0-0-0-ffff transformation.translation[0]
+data modify storage gm._temp_:std tv2p set string storage gm._temp_:std var2 0 1
+execute if data storage gm._temp_:std {tv2p:"-"} run data modify storage gm._temp_:std var2 set string storage gm._temp_:std var2 1
+execute if data storage gm._temp_:std {tv2p:"-"} run data modify storage gm._temp_:std v2p set value ""
+execute unless data storage gm._temp_:std {tv2p:"-"} run data modify storage gm._temp_:std v2p set value "-"
+data modify storage gm._temp_:std var2 set string storage gm._temp_:std var2 0 -1

--- a/data/gm/functions/zzz/modulo/truncate.mcfunction
+++ b/data/gm/functions/zzz/modulo/truncate.mcfunction
@@ -1,0 +1,9 @@
+#> gm:zzz/modulo/truncate
+#
+# Truncates var2
+#
+# ---
+# @context any
+# @within gm:modulo
+
+$execute store result storage gm._temp_:std var2 float $(v2p)1 run data get storage gm._temp_:std var2

--- a/data/gm/functions/zzz/subtract_handling.mcfunction
+++ b/data/gm/functions/zzz/subtract_handling.mcfunction
@@ -4,7 +4,7 @@
 #
 # ---
 # @context any
-# @within gm:subtract
+# @internal
 
 $execute positioned ~ $(var1) ~ run tp 91bb5-0-0-0-ffff 29999999 ~$(v2p)$(var2) 91665
 data modify storage gm:io out set from entity 91bb5-0-0-0-ffff Pos[1]


### PR DESCRIPTION
# The Suggestion
Comes from #11 
# Implementation description
- Uses an implementation of the `fmod` algorithm
  - `x % y = x - truncate(x / y) * y`
  - The truncation was the hardest part to figure out, because unlike `floor` which always rounds down, `truncate` rounds towards 0
- Implementation is fairly efficient, and is quite precise
- Allows for both decimal and negative values in both `x` and `y`
- Catches `y=0` by failing
- Updated README to add `gm:modulo` to list of functions