### PR TITLE
Fix Sqrt function

### DIFF
--- a/data/gm/function/sqrt.mcfunction
+++ b/data/gm/function/sqrt.mcfunction
@@ -9,10 +9,6 @@
 # # Fails
 # Will fail if `x < 0`
 #
-# # Unstable
-# In ***very rare*** cases, can run forever. If you find this occuring,
-# please report it at https://github.com/gibbsly/gm/issues
-#
 # ---
 # @context any
 # @api
@@ -23,6 +19,7 @@
 #   storage gm:io
 #      out: float | "fail"
 
+scoreboard players set __sqrt_loop gm.std 0
 data modify storage gm:io out set value "fail"
 $data merge storage gm._temp_:std {var1:$(x), var2:1, var3:[0d,0d,0d,0d,0d,1d,0d,0d,0d,0d,1d,0d,0d,0d,0d,2d], var4:[0f,0f,0f,$(x)f,0f,1f,0f,0f,0f,0f,1f,0f,0f,0f,0f,0f]}
 $return run function gm:zzz/sqrt_handling {var1:$(x), var2:1}

--- a/data/gm/function/zzz/load.mcfunction
+++ b/data/gm/function/zzz/load.mcfunction
@@ -10,7 +10,11 @@
 #define storage gm._temp_:std Standard transient storage
 #define storage gm._temp_:divide Division specific transient storage
 #define storage gm._temp_:check Type checking specific transient storage
+#define objective gm.std
 #define entity 91bb5-0-0-0-ffff
+
+scoreboard objectives remove gm.std
+scoreboard objectives add gm.std dummy
 
 forceload add 29999999 91665
 execute unless entity 91bb5-0-0-0-ffff run summon item_display 29999999 0 91665 {UUID:[I;596917,0,0,65535],CustomName:'"gm.math_entity"'}

--- a/data/gm/function/zzz/sqrt_handling.mcfunction
+++ b/data/gm/function/zzz/sqrt_handling.mcfunction
@@ -18,8 +18,10 @@ data modify storage gm._temp_:std var4[-1] set from storage gm._temp_:std var1
 data modify entity 91bb5-0-0-0-ffff transformation set from storage gm._temp_:std var4
 data modify storage gm._temp_:std var2 set from entity 91bb5-0-0-0-ffff transformation.translation[0]
 
+scoreboard players add __sqrt_loop gm.std 1
+
 function gm:zzz/sqrt/positive_subtract with storage gm._temp_:std
-execute unless data storage gm._temp_:std {v1m2p:"-"} run return run function gm:zzz/sqrt_handling with storage gm._temp_:std
+execute unless score __sqrt_loop gm.std matches 20.. unless data storage gm._temp_:std {v1m2p:"-"} run return run function gm:zzz/sqrt_handling with storage gm._temp_:std
 
 tp 91bb5-0-0-0-ffff 29999999 0 91665
 data modify storage gm:io out set from storage gm._temp_:std var1

--- a/pack.mcmeta
+++ b/pack.mcmeta
@@ -3,7 +3,7 @@
     "pack_format": 20,
     "supported_formats": {
       "min_inclusive": 20,
-      "max_inclusive": 26
+      "max_inclusive": 57
     },
     "description": "§7Floating Point Arithmetic §b- §7by gibbsly \n§7[§dgithub.com/gibbsly/gm§7]"
   }


### PR DESCRIPTION
# The Suggestion
Fix failures for certain values within `gm:sqrt`. This was a known issue, but now is the time to address it. The function failed due to floating point rounding error preventing the recursive algorithm from ever getting the max value within a certain threshold of the min value.
# Implementation Description
- Adds a scoreboard objective (`gm.std`) in the load function, to be used as any standard method for integer operations
- Updates `gm:sqrt` and `gm:zzz/sqrt_handling`, counting upwards from 0 in `__sqrt_loop` within `gm.std`, to count number of recursions.
- If accuracy threshold is met, `gm:sqrt` returns early
- If `__sqrt_loop` is ever greater than or equal to 20, `gm:sqrt` returns, preventing infinite recursion.
- Closes #15 
- Update IMP in `gm:sqrt` to reflect function fix
- Updates `max_inclusive` version in `pack.mcmeta` to `57` (version 1.21.3)